### PR TITLE
fix: use 0.0.0 for latest version when no previous versions found

### DIFF
--- a/pkg/gitsemver/project.go
+++ b/pkg/gitsemver/project.go
@@ -1,7 +1,6 @@
 package gitsemver
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -156,7 +155,7 @@ func (p Project) LatestVersion() (*semver.Version, error) {
 	versionsLen := len(versions) - 1
 
 	if versionsLen < 0 {
-		return &semver.Version{}, errors.New("no released versions found")
+		return semver.NewVersion("0.0.0")
 	}
 
 	return versions[versionsLen], nil


### PR DESCRIPTION
Fixes a bug that prevented to bump a project if it hadn't been previously tagged (i.e. there were no previous versions).

Now we return `0.0.0` as the latest version if we never bumped the project's version.