### PR TITLE
ci(release): added workflow to automatically release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ~1.17
+
+      - name: Install Git SemVer
+        run: go install .
+
+      - name: Bump Version
+        run: git semver bump
+
+      - id: release-bot
+        name: Authenticate with Release Bot
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.CB_RELEASE_BOT_ID }}
+          private_key: "${{ secrets.CB_RELEASE_BOT_PRIVATE_KEY }}"
+
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}


### PR DESCRIPTION
The workflow added will run on every push to `main` branch and:

- Automatically bump the project's version and create respective tag (using `git semver`: inception FTW)
- Build binaries for `linux`, `macos` and `windows`
- Create and publish a release on GitHub with all the build artifacts