### PR TITLE
feat: add support for basic auth on bump

### DIFF
--- a/internal/git/mod.go
+++ b/internal/git/mod.go
@@ -10,12 +10,15 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
 type Commit = object.Commit
 type Hash = plumbing.Hash
 type Repository = git.Repository
+type AuthMethod = transport.AuthMethod
+type BasicAuth = http.BasicAuth
 
 func OpenRepository(path string) (*Repository, error) {
 	return git.PlainOpen(path)
@@ -125,7 +128,7 @@ func CreateTag(repo *Repository, name, message string) error {
 	return err
 }
 
-func PushTagsToOrigin(repo *Repository) error {
+func PushTagsToOrigin(repo *Repository, auth AuthMethod) error {
 	// skip pushing if remote doesn't exist
 	if _, err := repo.Remote("origin"); err != nil {
 		return nil
@@ -135,10 +138,7 @@ func PushTagsToOrigin(repo *Repository) error {
 		RemoteName: "origin",
 		Progress:   os.Stdout,
 		RefSpecs:   []config.RefSpec{config.RefSpec("refs/tags/*:refs/tags/*")},
-		Auth: &http.BasicAuth{
-			Username: "git",
-			Password: os.Getenv("GITHUB_TOKEN"),
-		},
+		Auth:       auth,
 	}
 
 	if err := repo.Push(pushOpts); err != nil {

--- a/pkg/gitsemver/project.go
+++ b/pkg/gitsemver/project.go
@@ -13,6 +13,8 @@ import (
 
 type Increment int64
 type Change string
+type AuthMethod = git.AuthMethod
+type BasicAuth = git.BasicAuth
 
 const (
 	Major Increment = 4
@@ -215,7 +217,7 @@ func (p *Project) NextVersionIncrement() (Increment, error) {
 	return increment, nil
 }
 
-func (p *Project) Bump(versionFilenamesAndKeys []string) error {
+func (p *Project) Bump(versionFilenamesAndKeys []string, auth AuthMethod) error {
 	latest, err := p.LatestVersion()
 	if err != nil {
 		return err
@@ -251,7 +253,7 @@ func (p *Project) Bump(versionFilenamesAndKeys []string) error {
 		return err
 	}
 
-	if err := git.PushTagsToOrigin(p.Repo()); err != nil {
+	if err := git.PushTagsToOrigin(p.Repo(), auth); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- Add support for basic auth when pulling the tag to a remote origin
- Add flag `-u, --username` on `git semver bump`
- Add flag `-P, --password` on `git semver bump`