### PR TITLE
fix: limit version len to <15

### DIFF
--- a/internal/git/mod.go
+++ b/internal/git/mod.go
@@ -103,7 +103,7 @@ func FindTags(repo *Repository, reg *regexp.Regexp) ([]string, error) {
 	defer tags.Close()
 
 	err = tags.ForEach(func(ref *plumbing.Reference) error {
-		if reg.MatchString(ref.Name().Short()) {
+		if len(ref.Name().Short()) < 15 && reg.MatchString(ref.Name().Short()) {
 			matchTags = append(matchTags, ref.Name().Short())
 		}
 


### PR DESCRIPTION
Temporary workaround to skip tags like `v20220207182029`.