### PR TITLE
feat(bump): add --skip-tag flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ Bumps the latest version to the next version, creates a tag and pushes it to `or
 
 **Options:**
 
-| Name                 | Description                                                                |
-| -------------------- | -------------------------------------------------------------------------- |
-| `-P, --password`     | Password to use in HTTP basic authentication (useful for CI/CD pipelines)  |
-| `-u, --username`     | Username to use in HTTP basic authentication (useful for CI/CD pipelines)  |
-| `-f, --version-file` | Version files that should be updated. Format should be `filename:key`      |
+| Name                 | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| `-P, --password`     | Password to use in HTTP basic authentication (useful for CI/CD pipelines) |
+| `-u, --username`     | Username to use in HTTP basic authentication (useful for CI/CD pipelines) |
+| `-f, --version-file` | Version files that should be updated. Format should be `filename:key`     |
+| `--v-prefix`         | Prefix the version with a `v`                                             |
+| `--skip-tag`         | Don't create a new tag automatically                                      |
 
 **Example:**
 
@@ -56,6 +58,12 @@ $ git semver latest
 #### `git semver next`
 
 Outputs the next unreleased version.
+
+**Options:**
+
+| Name                 | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| `--v-prefix`         | Prefix the version with a `v`                                             |
 
 **Example:**
 

--- a/cmd/gitsemver/gitsemver.go
+++ b/cmd/gitsemver/gitsemver.go
@@ -22,6 +22,7 @@ var bumpCmd = &cobra.Command{
 		project := newProjectOrPanic(cmd)
 		versionFilenamesAndKeys := getVersionFilenamesAndKeysOrFail(cmd)
 		vPrefix := getVPrefixOrFail(cmd)
+		skipTag := getSkipTagOrFail(cmd)
 		username := getUsernameOrFail(cmd)
 		password := getPasswordOrFail(cmd)
 		latest := getLatestVersionOrFail(project)
@@ -36,7 +37,7 @@ var bumpCmd = &cobra.Command{
 			}
 		}
 
-		if err := project.Bump(versionFilenamesAndKeys, auth, vPrefix); err != nil {
+		if err := project.Bump(versionFilenamesAndKeys, auth, vPrefix, skipTag); err != nil {
 			log.Fatalln(err)
 		}
 
@@ -81,6 +82,7 @@ func init() {
 	bumpCmd.Flags().StringP("username", "u", "", "Username to use in HTTP basic authentication")
 	bumpCmd.Flags().StringP("password", "P", "", "Password to use in HTTP basic authentication")
 	bumpCmd.Flags().Bool("v-prefix", false, "Prefix the version with a `v`")
+	bumpCmd.Flags().Bool("skip-tag", false, "Don't create a new tag automatically")
 
 	nextCmd.Flags().Bool("v-prefix", false, "Prefix the version with a `v`")
 }
@@ -156,4 +158,13 @@ func getVPrefixOrFail(cmd *cobra.Command) bool {
 	}
 
 	return vPrefix
+}
+
+func getSkipTagOrFail(cmd *cobra.Command) bool {
+	skipTag, err := cmd.Flags().GetBool("skip-tag")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	return skipTag
 }

--- a/pkg/gitsemver/project.go
+++ b/pkg/gitsemver/project.go
@@ -234,7 +234,9 @@ func (p *Project) Bump(versionFilenamesAndKeys []string, auth AuthMethod, vPrefi
 		if err := git.CreateTag(p.Repo(), tagName, tagMessage); err != nil {
 			return err
 		}
+	}
 
+	if !skipTag || len(versionFilenamesAndKeys) > 0 {
 		if err := git.PushToOrigin(p.Repo(), auth); err != nil {
 			return err
 		}

--- a/pkg/gitsemver/project.go
+++ b/pkg/gitsemver/project.go
@@ -198,7 +198,7 @@ func (p *Project) NextVersionIncrement() (Increment, error) {
 	return increment, nil
 }
 
-func (p *Project) Bump(versionFilenamesAndKeys []string, auth AuthMethod, vPrefix bool) error {
+func (p *Project) Bump(versionFilenamesAndKeys []string, auth AuthMethod, vPrefix, skipTag bool) error {
 	latest, err := p.LatestVersion()
 	if err != nil {
 		return err
@@ -227,15 +227,17 @@ func (p *Project) Bump(versionFilenamesAndKeys []string, auth AuthMethod, vPrefi
 		}
 	}
 
-	tagName := TagNameFromProjectAndVersion(p, next)
-	tagMessage := fmt.Sprintf("Release %s", tagName)
+	if !skipTag {
+		tagName := TagNameFromProjectAndVersion(p, next)
+		tagMessage := fmt.Sprintf("Release %s", tagName)
 
-	if err := git.CreateTag(p.Repo(), tagName, tagMessage); err != nil {
-		return err
-	}
+		if err := git.CreateTag(p.Repo(), tagName, tagMessage); err != nil {
+			return err
+		}
 
-	if err := git.PushToOrigin(p.Repo(), auth); err != nil {
-		return err
+		if err := git.PushToOrigin(p.Repo(), auth); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Adds a `--skip-tag` flag to the `bump` command. This will still create a commit modifying any specified version files and commit them, but will not create a tag. This allows the users to create the tag themselves from the commit they want.